### PR TITLE
Raking Canary's in Windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ task :install, :backup do |t, args|
     chrome_dirs.push File.join(home_dir, "Library", "Application Support", "Google", "Chrome Canary")
   elsif OS.win?
     chrome_dirs.push File.join(home_dir, "AppData", "Local", "Google", "Chrome", "User Data")
-    chrome_dirs.push File.join(home_dir, "AppData", "Local", "Google", "Chrome Canary", "User Data")
+    chrome_dirs.push File.join(home_dir, "AppData", "Local", "Google", "Chrome SxS", "User Data")
   else
     puts "Unsuported OS..."
   end


### PR DESCRIPTION
Google Chrome Canary on Windows 8.1 x64 uses the folder 'Chrome SxS'

Awesome addition to the repo, thanks y'all @rudisimo @simonowendesign
